### PR TITLE
Version 1.1.2 - Bronze Ingestion Finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,48 @@
 # New York Times - Top Stories
+*Beyond the headlines: What insights can we uncover from the news displayed in the front page of the world's biggest newspaper?*
+
+___
+
+##About this project
+
 The New York Times provides API endpoints that allow users to get data from their website, including news from a specific period, reviews and the top stories - which is the data source of this project.
 
-Data provided by the New York Times at https://developer.nytimes.com/.
+This project aims build a pipeline that allow us to get the Top Stories of each day, save then to corresponding data lakers - Bronze, Silver and Gold - and analyze the data to identify recurring topics, build ML models etc.
 
-This project aims build a pipeline that allow us to get the Top Stories of each day, save then to corresponding data lakers - Bronze, Silver and Gold - and analyze the data to identify recurring topics, build ML models etc. 
+**Credits**
 
-**Project's Architecture**
+All the data used in this project is provided by the New York Times at https://developer.nytimes.com/.
 
-This first version includes an Lambda Function that runs once a day até 14 p.m to get the top stories from the API, and save then to a S3 Bucket in AWS. The data is then readed by a Scheduled Job in Databricks, that identifies when a new file has been added to the Bucket, and triggers a Python code that compiles all the files in the bucket and save then into a Delta Table in a Bronze Layer dataset.
+This project is based in the "Lago do Mago" project built by Teo Me Why. Téo provides free courses about data analytics, engineering and machine learning.
 
+His videos can be found at https://www.youtube.com/@teomewhy
+
+##**Project's Architecture**
+
+### Ingestion Pipelines
+The Medallion Architecture is the foundation of the data structure of the project.
 
 <img width="1195" height="727" alt="Architecture" src="https://github.com/user-attachments/assets/5326bc02-4b63-4094-86f5-9a1cdfb0a259" />
 
+**1. Raw Data Layer**
 
-**Backlog**
+The raw data is extracted from the NY Times API through a Lambda Function scheduled to run daily at 19 p.m (UTC). The data is saved in a S3 Bucket in AWS without additional treatments, with the exception of including the reference date which the news were extracted.
 
-- Implement an incremental update in the bronze layer
-- Build silver and gold layers
+**2. Bronze Data Layer**
+
+With the raw data saved to S3, we read this data using a Scheduled Job in Databricks. The python code uses Databricks Autoloader to identify new files that have been added to the S3 Bucket, proccess the new data and add then into a Delta Table, adding the ingestion date to it's contents. No further treatments are made
+
+**3. Silver Data Layer**
+
+*Coming in future updates...*
+
+
+**4. Gold Data Layer**
+
+*Coming in future updates...*
+
+
+### Data Analysis
+*Coming in future updates...*
+
 

--- a/src/bronze/Bronze - Ingestion.ipynb
+++ b/src/bronze/Bronze - Ingestion.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "from datetime import datetime\n",
     "from pyspark.sql.functions import lit\n",
-    "from pyspark.sql.types import StructType,StructField, StringType, IntegerType, ArrayType, LongType"
+    "from pyspark.sql.types import StructType, StructField, StringType, IntegerType, ArrayType, LongType"
    ]
   },
   {
@@ -80,9 +80,49 @@
     "        StructField(\"updated_date\", StringType(), True),\n",
     "        StructField(\"uri\", StringType(), True),\n",
     "        StructField(\"url\", StringType(), True),\n",
+    "        StructField('ref_date', StringType(), True),\n",
     "        StructField(\"ingestion_date\", StringType(), True),\n",
     "    ]\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "4bb63afa-edf1-41a3-aa8b-857d641ab243",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "table_exists = spark.sql('''\n",
+    "  SELECT COUNT(*)\n",
+    "  FROM bronze.information_schema.tables\n",
+    "  WHERE table_schema = 'nytimes'\n",
+    "    AND table_name = 'top_stories';\n",
+    "''').collect()[0][0]\n",
+    "\n",
+    "if table_exists == 0:\n",
+    "    print('Creating top_stories table...')\n",
+    "    df_creation = spark.createDataFrame([], schema=stream_schema)\n",
+    "    (df_creation.write\n",
+    "     .format('delta')\n",
+    "     .mode('overwrite')\n",
+    "     .partitionBy('ref_date')\n",
+    "     .saveAsTable('bronze.nytimes.top_stories')\n",
+    "    )\n",
+    "    print('top_stories table created successfully')\n",
+    "else:\n",
+    "    print('top_stories table already exists')"
    ]
   },
   {
@@ -105,11 +145,13 @@
    "source": [
     "def ingestion(df):\n",
     "    df = df.withColumn('ingestion_date', lit(datetime.now().strftime('%Y-%m-%d')))\n",
+    "    df.createOrReplaceTempView('payload')\n",
     "\n",
-    "    (df.write\n",
-    "        .partitionBy('ingestion_date')\n",
-    "        .mode('overwrite')\n",
-    "        .saveAsTable('bronze.nytimes.top_stories'))\n"
+    "    spark.sql('''\n",
+    "        INSERT INTO bronze.nytimes.top_stories\n",
+    "        REPLACE USING (ref_date)\n",
+    "        SELECT * FROM payload\n",
+    "    ''')\n"
    ]
   },
   {
@@ -185,64 +227,17 @@
    "source": [
     "start = stream.start()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "implicitDf": true,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "a5c58219-503e-4724-9150-8c7454993243",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Validation: Partitions"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%sql\n",
-    "\n",
-    "SHOW PARTITIONS bronze.nytimes.top_stories;"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "implicitDf": true,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "c6137784-9fc6-4e9a-a466-b2f440bd734a",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Validation: Rows"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%sql\n",
-    "\n",
-    "SELECT \n",
-    "  ingestion_date, \n",
-    "  COUNT(*) AS entries\n",
-    "FROM bronze.nytimes.top_stories\n",
-    "GROUP BY ingestion_date\n",
-    ";"
-   ]
   }
  ],
  "metadata": {
   "application/vnd.databricks.v1+notebook": {
-   "computePreferences": null,
+   "computePreferences": {
+    "hardware": {
+     "accelerator": null,
+     "gpuPoolId": null,
+     "memory": null
+    }
+   },
    "dashboards": [],
    "environmentMetadata": {
     "base_environment": "",
@@ -252,7 +247,7 @@
    "language": "python",
    "notebookMetadata": {
     "mostRecentlyExecutedCommandWithImplicitDF": {
-     "commandId": 5718192201273298,
+     "commandId": 8487397785821354,
      "dataframes": [
       "_sqldf"
      ]

--- a/src/bronze/Bronze - Ingestion.ipynb
+++ b/src/bronze/Bronze - Ingestion.ipynb
@@ -13,13 +13,14 @@
      "nuid": "fe9e44c7-6e2e-42ee-9102-bc6a0f226a21",
      "showTitle": true,
      "tableResultSettingsMap": {},
-     "title": "Import"
+     "title": "Configuration"
     }
    },
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
-    "from pyspark.sql.functions import lit"
+    "from pyspark.sql.functions import lit\n",
+    "from pyspark.sql.types import StructType,StructField, StringType, IntegerType, ArrayType, LongType"
    ]
   },
   {
@@ -32,24 +33,56 @@
       "rowLimit": 10000
      },
      "inputWidgets": {},
-     "nuid": "fdbee93b-05a9-4879-8b28-3231b7ca4be4",
+     "nuid": "ddaba545-31aa-4ee5-a76c-eae69d456d8c",
      "showTitle": true,
-     "tableResultSettingsMap": {
-      "0": {
-       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{\"url\":{\"format\":{\"preset\":\"string-preset-url\"}}}},\"syncTimestamp\":1756328780613}",
-       "filterBlob": null,
-       "queryPlanFiltersBlob": null,
-       "tableResultIndex": 0
-      }
-     },
-     "title": "Full Load Dataframe Creation"
+     "tableResultSettingsMap": {},
+     "title": "Stream Schema Definition"
     }
    },
    "outputs": [],
    "source": [
-    "df_full_load = spark.read.format('json').load('/Volumes/raw/nytimes/top_stories')\n",
-    "df_full_load = df_full_load.withColumn('ingestion_date', lit(datetime.now().strftime('%Y-%m-%d')))\n",
-    "df_full_load.display()"
+    "stream_schema = StructType(\n",
+    "    [\n",
+    "        StructField(\"abstract\", StringType(), True),\n",
+    "        StructField(\"byline\", StringType(), True),\n",
+    "        StructField(\"created_date\", StringType(), True),\n",
+    "        StructField(\"des_facet\", ArrayType(StringType(), True), True),\n",
+    "        StructField(\"geo_facet\", ArrayType(StringType(), True), True),\n",
+    "        StructField(\"item_type\", StringType(), True),\n",
+    "        StructField(\"kicker\", StringType(), True),\n",
+    "        StructField(\"material_type_facet\", StringType(), True),\n",
+    "        StructField(\n",
+    "            \"multimedia\",\n",
+    "            ArrayType(\n",
+    "                StructType(\n",
+    "                    [\n",
+    "                        StructField(\"caption\", StringType(), True),\n",
+    "                        StructField(\"copyright\", StringType(), True),\n",
+    "                        StructField(\"format\", StringType(), True),\n",
+    "                        StructField(\"height\", LongType(), True),\n",
+    "                        StructField(\"subtype\", StringType(), True),\n",
+    "                        StructField(\"type\", StringType(), True),\n",
+    "                        StructField(\"url\", StringType(), True),\n",
+    "                        StructField(\"width\", LongType(), True),\n",
+    "                    ]\n",
+    "                ),\n",
+    "                True,\n",
+    "            ),\n",
+    "            True,\n",
+    "        ),\n",
+    "        StructField(\"org_facet\", ArrayType(StringType(), True), True),\n",
+    "        StructField(\"per_facet\", ArrayType(StringType(), True), True),\n",
+    "        StructField(\"published_date\", StringType(), True),\n",
+    "        StructField(\"section\", StringType(), True),\n",
+    "        StructField(\"short_url\", StringType(), True),\n",
+    "        StructField(\"subsection\", StringType(), True),\n",
+    "        StructField(\"title\", StringType(), True),\n",
+    "        StructField(\"updated_date\", StringType(), True),\n",
+    "        StructField(\"uri\", StringType(), True),\n",
+    "        StructField(\"url\", StringType(), True),\n",
+    "        StructField(\"ingestion_date\", StringType(), True),\n",
+    "    ]\n",
+    ")"
    ]
   },
   {
@@ -62,21 +95,95 @@
       "rowLimit": 10000
      },
      "inputWidgets": {},
-     "nuid": "c6cd7ad2-457c-4ed7-9007-1b0512ffdc56",
-     "showTitle": false,
+     "nuid": "ba37aa12-0c15-44b4-b669-288da003e9b5",
+     "showTitle": true,
      "tableResultSettingsMap": {},
-     "title": ""
+     "title": "Ingestion Function"
     }
    },
    "outputs": [],
    "source": [
-    "(\n",
-    "    df_full_load.write\n",
-    "        .format('delta')\n",
-    "        .mode('overwrite')\n",
+    "def ingestion(df):\n",
+    "    df = df.withColumn('ingestion_date', lit(datetime.now().strftime('%Y-%m-%d')))\n",
+    "\n",
+    "    (df.write\n",
     "        .partitionBy('ingestion_date')\n",
-    "        .saveAsTable('bronze.nytimes.top_stories')        \n",
+    "        .mode('overwrite')\n",
+    "        .saveAsTable('bronze.nytimes.top_stories'))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "1e6b1b81-55e2-4a0b-8ca0-ee4723e998fc",
+     "showTitle": true,
+     "tableResultSettingsMap": {},
+     "title": "Reading Stream"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df_stream = (spark.readStream\n",
+    "                .format('cloudFiles')\n",
+    "                .option('cloudFiles.format', 'json')\n",
+    "                .schema(stream_schema)\n",
+    "                .load('/Volumes/raw/nytimes/top_stories')\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "dfaf03b2-eea0-4364-8124-4372145127c3",
+     "showTitle": true,
+     "tableResultSettingsMap": {},
+     "title": "Writing Stream"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stream = (df_stream.writeStream\n",
+    "    .option(\"checkpointLocation\", \"/Volumes/raw/nytimes/top_stories_checkpoint/\")\n",
+    "    .foreachBatch(\n",
+    "        lambda df, epoch_id: ingestion(df)\n",
+    "    )\n",
+    "    .trigger(availableNow=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "7cb1c7b5-b017-470a-b005-112b6c182f56",
+     "showTitle": true,
+     "tableResultSettingsMap": {},
+     "title": "Stream execution"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "start = stream.start()"
    ]
   },
   {
@@ -91,9 +198,9 @@
      },
      "inputWidgets": {},
      "nuid": "a5c58219-503e-4724-9150-8c7454993243",
-     "showTitle": false,
+     "showTitle": true,
      "tableResultSettingsMap": {},
-     "title": ""
+     "title": "Validation: Partitions"
     }
    },
    "outputs": [],
@@ -115,16 +222,21 @@
      },
      "inputWidgets": {},
      "nuid": "c6137784-9fc6-4e9a-a466-b2f440bd734a",
-     "showTitle": false,
+     "showTitle": true,
      "tableResultSettingsMap": {},
-     "title": ""
+     "title": "Validation: Rows"
     }
    },
    "outputs": [],
    "source": [
     "%sql\n",
     "\n",
-    "SELECT * FROM bronze.nytimes.top_stories LIMIT 100;"
+    "SELECT \n",
+    "  ingestion_date, \n",
+    "  COUNT(*) AS entries\n",
+    "FROM bronze.nytimes.top_stories\n",
+    "GROUP BY ingestion_date\n",
+    ";"
    ]
   }
  ],


### PR DESCRIPTION
Finished the Bronze Data Layer ingestion pipeline. 
The pipeline has been updated to an incremental mode, using Databricks Autoloader. Now, instead of reading all the files in the S3 Bucket and overwriting the whole table at the Bronze Layer, the pipeline identifies the new files and updates the table according to the dates
