### PR TITLE
Feature: CDF Silver Ingestion

### DIFF
--- a/src/bronze/Bronze - Ingestion.ipynb
+++ b/src/bronze/Bronze - Ingestion.ipynb
@@ -228,6 +228,7 @@
    "source": [
     "stream = (df_stream.writeStream\n",
     "    .option(\"checkpointLocation\", stream_checkpoint)\n",
+    "    .toTable()\n",
     "    .foreachBatch(\n",
     "        lambda df, epoch_id: ingestion(df)\n",
     "    )\n",

--- a/src/silver/cdf/Silver - Ingestion.ipynb
+++ b/src/silver/cdf/Silver - Ingestion.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "0728e335-61be-4b2f-9962-98f1d2ad605c",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def ingestion(df):\n",
+    "    df.createOrReplaceTempView('payload')\n",
+    "    \n",
+    "    spark.sql('''\n",
+    "        INSERT INTO silver.nytimes.top_stories_test\n",
+    "        REPLACE USING (ref_date)\n",
+    "        SELECT\n",
+    "        title AS ds_headline,\n",
+    "        abstract AS ds_lead,\n",
+    "        SPLIT(REPLACE(REPLACE(byline, 'By ', ''), ' and ', ', '), ', ') AS ds_authors,\n",
+    "        section AS ds_section,\n",
+    "        subsection AS ds_subsection,\n",
+    "        url AS ds_url,\n",
+    "        geo_facet AS ds_locations,\n",
+    "        des_facet AS ds_topics,\n",
+    "        org_facet AS ds_organizations,\n",
+    "        per_facet AS ds_persons,\n",
+    "        published_date,\n",
+    "        ref_date AS ref_date\n",
+    "        FROM payload        \n",
+    "    ''')\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d8420e4f-5d64-4dd6-9bd9-26a96e5e59c3",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df_stream = (spark.readStream\n",
+    "    .option('readChangeFeed', 'true')\n",
+    "    .table('bronze.nytimes.top_stories')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "2743d706-cc83-466d-8c76-9ba0698e737d",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stream = (df_stream.writeStream\n",
+    "    .option('checkpointLocation', '/Volumes/silver/nytimes/top_stories_checkpoint_test')\n",
+    "    .foreachBatch(lambda batch_df, batch_id: ingestion(batch_df))\n",
+    "    .trigger(availableNow=True)\n",
+    "    #.toTable('silver.nytimes.top_stories_test')          \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "bc42c6e5-a3ef-4657-bc1f-2b26b343673f",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stream.start()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "867ec893-c20f-47c2-8aa9-c52ec876a9fe",
+     "showTitle": false,
+     "tableResultSettingsMap": {
+      "0": {
+       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{\"ds_url\":{\"format\":{\"preset\":\"string-preset-url\"}}}},\"syncTimestamp\":1757864127191}",
+       "filterBlob": null,
+       "queryPlanFiltersBlob": null,
+       "tableResultIndex": 0
+      }
+     },
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%sql\n",
+    "\n",
+    "SELECT * FROM silver.nytimes.top_stories_test;"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "3"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 7253829310469410,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "Silver - Ingestion",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/src/silver/cdf/top_stories.sql
+++ b/src/silver/cdf/top_stories.sql
@@ -1,0 +1,14 @@
+SELECT
+  title AS ds_headline,
+  abstract AS ds_lead,
+  SPLIT(REPLACE(REPLACE(byline, 'By ', ''), ' and ', ', '), ', ') AS ds_authors,
+  section AS ds_section,
+  subsection AS ds_subsection,
+  url AS ds_url,
+  geo_facet AS ds_locations,
+  des_facet AS ds_topics,
+  org_facet AS ds_organizations,
+  per_facet AS ds_persons,
+  published_date,
+  ref_date AS ref_date
+FROM bronze.nytimes.top_stories

--- a/src/workflows/nytimes.json
+++ b/src/workflows/nytimes.json
@@ -76,6 +76,40 @@
           "alert_on_last_attempt": false
         },
         "webhook_notifications": {}
+      },
+      {
+        "task_key": "Silver_Ingestion_TopStories_TEST",
+        "depends_on": [
+          {
+            "task_key": "Silver_Ingestion_TopStories"
+          }
+        ],
+        "run_if": "ALL_SUCCESS",
+        "notebook_task": {
+          "notebook_path": "src/silver/cdf/Silver - Ingestion",
+          "base_parameters": {
+            "database_name": "silver",
+            "schema_name": "nytimes",
+            "table_name": "top_stories"
+          },
+          "source": "GIT"
+        },
+        "timeout_seconds": 0,
+
+        "email_notifications": {
+          "on_success": [
+            "DATABRICKS_USER"
+          ],
+          "on_failure": [
+            "DATABRICKS_USER"
+          ]
+        },
+        "notification_settings": {
+          "no_alert_for_skipped_runs": false,
+          "no_alert_for_canceled_runs": false,
+          "alert_on_last_attempt": false
+        },
+        "webhook_notifications": {}
       }
     ],
     "git_source": {


### PR DESCRIPTION
Built a test pipeline that uses Delta Change Data Feed to update the Silver table based on the changes made to the Bronze table. This test will run in a temporary table to check its behavior, and once it turns successfull, it will be implemented to the main process